### PR TITLE
Fix typo in root_pattern to root_patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ require('plug').add({
     'wsdjeg/rooter.nvim',
     config = function()
       require('rooter').setup({
-        root_pattern = { '.git/' },
+        root_patterns = { '.git/' },
       })
     end,
   }


### PR DESCRIPTION
Was scratching my head for a long time why config wasn't working and caught this error in the readme