### PR TITLE
fix(sort): use a strict comparator to fix "invalid order function for sorting"

### DIFF
--- a/lua/rooter/init.lua
+++ b/lua/rooter/init.lua
@@ -99,8 +99,12 @@ local function compare(d1, d2)
     local al = #vim.split(d1, '/')
     local bl = #vim.split(d2, '/')
     if rooter_config.outermost then
-        -- sort ascending: the shallowest dir comes first
-        return al <= bl
+        -- sort ascending: the shallowest dir comes first;
+        -- must be a strict comparator (with a deterministic tie-break),
+        -- otherwise two roots with the same path depth -- e.g. two patterns
+        -- matching the same directory -- make table.sort throw
+        -- "invalid order function for sorting"
+        return al < bl or (al == bl and d1 < d2)
     else
         -- sort descending: the deepest dir comes first
         return al > bl


### PR DESCRIPTION
## Problem

With the default `outermost = true`, `compare()` returns `al <= bl`, which is **not a strict weak ordering**. `table.sort` requires a strict comparator and throws:

```
Error in BufEnter Autocommands for "*":
Lua callback: .../opt/rooter/lua/rooter/init.lua:196: invalid order function for sorting
stack traceback:
        [C]: in function 'sort'
        .../lua/rooter/init.lua:196: in function 'find_root_directory'
```

This triggers whenever two collected roots have the same path depth — the most common case being **two `root_patterns` matching the same directory**, e.g. `flake.nix` and `Cargo.toml` both sitting in the project root (any nix + rust project):

```lua
require("rooter").setup({ root_patterns = { "flake.nix", ".git/", ".jj/", "Cargo.toml", "go.mod", "package.json" } })
-- open any file in a project whose root contains both flake.nix and Cargo.toml
```

For such a pair, `compare(a, b)` and `compare(b, a)` are both `true`, so the error fires on every `BufEnter`/`BufWritePost`.

## Fix

Make the `outermost` branch strict and add a lexicographic tie-break so the result is deterministic for equal-depth roots (e.g. duplicate entries collected from different patterns):

```lua
if rooter_config.outermost then
    return al < bl or (al == bl and d1 < d2)
else
    return al > bl
end
```

(The `outermost = false` branch was already strict.)

Verified on the reproducer above: the error disappears and the correct project root is selected on `BufEnter` and after `:w`.